### PR TITLE
Fix code scanning alert no. 1: Use of externally-controlled format string

### DIFF
--- a/autoreloader.js
+++ b/autoreloader.js
@@ -33,7 +33,7 @@ window.autoreloader = {
             try {
                 const response = await fetch(file.src || file.href, { cache: 'no-store', method: 'HEAD', timeout: 5000 });
                 const lastModified = response.headers.get('last-modified');
-                console.log(file.src, lastModified);
+                console.log('%s', file.src, lastModified);
                 window.autoreloader.noConnection = false;
                 if (lastModified && new Date(lastModified).getTime() > startTime) {
                     window.autoreloader.shouldReload = true;


### PR DESCRIPTION
Fixes [https://github.com/magentapenguin/scroll-game/security/code-scanning/1](https://github.com/magentapenguin/scroll-game/security/code-scanning/1)

To fix the problem, we should ensure that any untrusted input is properly sanitized before being used in a format string. In this case, we can use the `%s` specifier in the format string and pass the untrusted data as a corresponding argument. This approach ensures that the untrusted data is treated as a string and prevents any unintended format specifiers from being processed.

Specifically, we need to modify the `console.log` statement on line 36 to use a format string with the `%s` specifier and pass `file.src` as an argument.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
